### PR TITLE
Update deprecated module name in Ubuntu configuration

### DIFF
--- a/cloudcfg/cloud.cfg.ubuntu.yml
+++ b/cloudcfg/cloud.cfg.ubuntu.yml
@@ -24,7 +24,7 @@ cloud_config_modules:
   - grub-dpkg
   - apt-pipelining
   - apt-configure
-  - ubuntu-advantage
+  - ubuntu-pro
   - ntp
   - timezone
   - disable-ec2-metadata


### PR DESCRIPTION
## Description
```
2025-04-10 13:43:17,028 - lifecycle.py[DEPRECATED]: Module has been renamed from cc_ubuntu_advantage to cc_ubuntu_pro. Update any references in /etc/cloud/cloud.cfg is deprecated in 24.1 and scheduled to be removed in 29.1.
```

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
